### PR TITLE
Modify the top driver for retro run

### DIFF
--- a/src/SYSTEM/create_namelist.input.bash
+++ b/src/SYSTEM/create_namelist.input.bash
@@ -9,6 +9,7 @@ eyear=${3:0:4}
 emon=${3:4:2}
 eday=${3:6:2}
 ehr=${3:8:2}
+num_metgrid_levels=$4
 
 if [ $shr -eq 00 ]
 then
@@ -53,7 +54,7 @@ cat << EOF > $fileo
  e_sn                                = 200,    281,   229,
  e_vert                              = 50,     50,    43,
  p_top_requested                     = 5000,
- num_metgrid_levels                  = 32,
+ num_metgrid_levels                  = ${num_metgrid_levels},
  num_metgrid_soil_levels             = 4,
  dx                                  = 15000, 3000,  3000,
  dy                                  = 15000, 3000,  3000,


### PR DESCRIPTION
As mentioned in #7, now the top driver (run_wrfgsi.bash) can be used for the retro run with two new variables.
Additional if-statements creating run and output folders are added as well.
@Hui4ying3LUO2, please give it a try and see if it works.